### PR TITLE
fix: mediaSubtype

### DIFF
--- a/src/ImageBrowser.js
+++ b/src/ImageBrowser.js
@@ -6,7 +6,8 @@ import {
   FlatList,
   Dimensions,
   Button,
-  ActivityIndicator
+  ActivityIndicator,
+  Platform
 } from 'react-native'
 
 import * as MediaLibrary from 'expo-media-library'
@@ -63,7 +64,7 @@ export default class ImageBrowser extends React.Component {
     if (this.state.after === assets.endCursor) return
 
     let displayAssets
-    if (this.props.mediaSubtype == null) {
+    if (Platform.OS !== 'ios' || this.props.mediaSubtype == null) {
       displayAssets = assets.assets
     } else {
       displayAssets = assets.assets.filter((asset) => {


### PR DESCRIPTION
When Android Develop, it occur error when if 'media Subtype' parameter was passed. I think it's  better to handle it inside of this module than developer handle it by platform :)
If you have different thinking, i want to listen about your thought. :) thanks.